### PR TITLE
Check added for binary and octal number

### DIFF
--- a/Calculators/NumberSystemCoversion_Calculator/operation.js
+++ b/Calculators/NumberSystemCoversion_Calculator/operation.js
@@ -29,27 +29,27 @@ function determine(){
 }
 //funciton for binary to octal
 function bintooct(iNum){
-    return parseInt(iNum,2).toString(8);
+    return /^[01]+$/.test(iNum) ? parseInt(iNum,2).toString(8) : "Binary number has only 0 and 1";
 }
 //funciton for binary to decimal
 function bintodec(iNum){
-    return parseInt(iNum,2);
+    return  /^[01]+$/.test(iNum) ? parseInt(iNum,2) : "Binary number has only 0 and 1";
 }
 //funciton for binary to hexa
 function bintohex(iNum){
-    return parseInt(iNum,2).toString(16);
+    return /^[01]+$/.test(iNum) ? parseInt(iNum,2).toString(16): "Binary number has only 0 and 1";
 }
 //funciton for octal to binary
 function octtobin(iNum){
-    return parseInt(iNum,8).toString(2);
+    return /^[0-7]+$/.test(iNum) ? parseInt(iNum,8).toString(2): "Octal number has digits 0 to 7 only";
 }
 //funciton for octal to decimal
 function octtodec(iNum){
-    return parseInt(iNum,8);
+    return /^[0-7]+$/.test(iNum) ? parseInt(iNum,8): "Octal number has digits 0 to 7 only";
 }
 //funciton for octal to hexa
 function octtohex(iNum){
-    return parseInt(iNum,8).toString(16);
+    return /^[0-7]+$/.test(iNum) ? parseInt(iNum,8).toString(16): "Octal number has digits 0 to 7 only";
 }
 //funciton for decimal to binary
 function dectobin(iNum){


### PR DESCRIPTION
## Description 📜

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
Fixes #268 
Added check for binary and octal numbers in the number system conversion calculator so that it gives results only when a valid binary and octal number are entered and shows an error if they are not valid.

<hr>
 
## Checklist ✅

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [Contributing Guidelines](https://github.com/vasu-1/CalcHub/blob/main/.github/ContributingGuidelines.md) & [Code of conduct](https://github.com/vasu-1/CalcHub/blob/main/.github/CODE_OF_CONDUCT.MD) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I'm GSSOC'22 contributor
<hr>

![Screenshot (2)](https://user-images.githubusercontent.com/72207545/165095009-6e5888bd-db19-45a6-adad-94b0400e2591.png)
![Screenshot (3)](https://user-images.githubusercontent.com/72207545/165095020-c701fb27-4233-4dc8-a1d3-c4973a370791.png)

